### PR TITLE
Modify regex so nerdtree-git-plugin markings are not highlighted.

### DIFF
--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -353,8 +353,8 @@ for [key, val] in items(s:file_extension_colors)
 endfor
 
 for [key, val] in items(g:NERDTreeExtensionHighlightColor)
-  exec 'silent syn match nerdtreeFileExtensionLabel_'.key.' ".*\.'.key.'$" containedin=NERDTreeFile'
-  exec 'silent syn match nerdtreeFileExtensionLabel_'.key.' ".*\.'.key.'\*$" containedin=NERDTreeExecFile'
+  exec 'silent syn match nerdtreeFileExtensionLabel_'.key.' "\s*\(\[.\+\]\)\?\zs.*\.'.key.'$" containedin=NERDTreeFile'
+  exec 'silent syn match nerdtreeFileExtensionLabel_'.key.' "\s*\(\[.\+\]\)\?\zs.*\.'.key.'\*$" containedin=NERDTreeExecFile'
   exec 'hi def link nerdtreeFileExtensionLabel_'.key.' NERDTreeFile'
 
   if exists('g:WebDevIconsUnicodeDecorateFileNodesExtensionSymbols["'.key.'"]')


### PR DESCRIPTION
The nerdtree-git-plugin plugin decorates the filenames in NERDTree with
glyphs indicating the files' status changes. These glyphs are
highlighted differently than the filename. However, when this plugin
also is used, it overrides the glyph's highlighting with its syntax
match definitions.

This commit modifies the regexes on the syn match statements so that any
leading characters in square brackets are ignored, and only the filename
is highlighted.