### PR TITLE
Adding NERDTree syntax colors for Elixir lang

### DIFF
--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -313,6 +313,7 @@ let s:file_extension_colors = {
 \}
 
 let s:file_node_exact_matches = {
+  \ 'mix.lock'                         : s:lightPurple,
   \ 'gruntfile.coffee'                 : s:yellow,
   \ 'gruntfile.js'                     : s:yellow,
   \ 'gruntfile.ls'                     : s:yellow,

--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -301,6 +301,8 @@ let s:file_extension_colors = {
   \ 'rlib'     : s:darkOrange,
   \ 'd'        : s:red,
   \ 'erl'      : s:lightPurple,
+  \ 'ex'       : s:lightPurple,
+  \ 'exs'      : s:lightPurple,
   \ 'hrl'      : s:pink,
   \ 'vim'      : s:green,
   \ 'ai'       : s:darkOrange,

--- a/generate_files.sh
+++ b/generate_files.sh
@@ -91,6 +91,7 @@ exact_match_folders=(
 )
 
 exact_matches=(
+  \ 'mix.lock'
   \ 'gruntfile.coffee'
   \ 'gruntfile.js'
   \ 'gruntfile.ls'

--- a/generate_files.sh
+++ b/generate_files.sh
@@ -74,6 +74,8 @@ extensions=(
   \ 'rlib'
   \ 'd'
   \ 'erl'
+  \ 'ex'
+  \ 'exs'
   \ 'hrl'
   \ 'vim'
   \ 'ai'


### PR DESCRIPTION
I just wanted the little elixir droplet icons to be light-purple like they're supposed to be:

<img width="396" alt="elixir_support" src="https://user-images.githubusercontent.com/85241/71518302-1b8d0700-28aa-11ea-8d5d-e50205ff2aad.png">
