### PR TITLE
Suppress error when vim-devicons is missing

### DIFF
--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -558,31 +558,35 @@ for [key, val] in items(g:NERDTreePatternMatchHighlightColor)
   endif
 endfor
 
-let icon_closed = g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol
-let icon_open = g:DevIconsDefaultFolderOpenSymbol
-let identifier = 'WebDevIconsDefaultFolderSymbol'
-exec 'silent syn match '.identifier.' "\c['.icon_closed.']\ze.*/" containedin=NERDTreeFlags'
-exec 'silent syn match '.identifier.' "\c['.icon_open.']\ze.*/" containedin=NERDTreeFlags'
-if !exists('g:WebDevIconsDisableDefaultFolderSymbolColorFromNERDTreeDir')
-  exec 'hi def link '.identifier.' NERDTreeDir'
-else
-  " exec 'hi def link '.identifier.' NERDTreeFlags'
-  let NERDTreeFlagsTrans = synIDattr(synIDtrans(hlID('NERDTreeFlags')), 'name')
-  exec 'hi def link '.identifier.' '.NERDTreeFlagsTrans
-endif
-if exists('g:WebDevIconsDefaultFolderSymbolColor')
-  call s:X(identifier, g:WebDevIconsDefaultFolderSymbolColor, '', '')
+if exists("g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol")
+  let icon_closed = g:WebDevIconsUnicodeDecorateFolderNodesDefaultSymbol
+  let icon_open = g:DevIconsDefaultFolderOpenSymbol
+  let identifier = 'WebDevIconsDefaultFolderSymbol'
+  exec 'silent syn match '.identifier.' "\c['.icon_closed.']\ze.*/" containedin=NERDTreeFlags'
+  exec 'silent syn match '.identifier.' "\c['.icon_open.']\ze.*/" containedin=NERDTreeFlags'
+  if !exists('g:WebDevIconsDisableDefaultFolderSymbolColorFromNERDTreeDir')
+    exec 'hi def link '.identifier.' NERDTreeDir'
+  else
+    " exec 'hi def link '.identifier.' NERDTreeFlags'
+    let NERDTreeFlagsTrans = synIDattr(synIDtrans(hlID('NERDTreeFlags')), 'name')
+    exec 'hi def link '.identifier.' '.NERDTreeFlagsTrans
+  endif
+  if exists('g:WebDevIconsDefaultFolderSymbolColor')
+    call s:X(identifier, g:WebDevIconsDefaultFolderSymbolColor, '', '')
+  endif
 endif
 
-let icon = g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol
-let identifier = 'WebDevIconsDefaultFileSymbol '
-exec 'silent syn match '.identifier.' "\v\c\zs['.icon.']\ze.*" containedin=NERDTreeFlags'
-if !exists('g:WebDevIconsDisableDefaultFileSymbolColorFromNERDTreeFile')
-  exec 'hi def link '.identifier.' NERDTreeFile'
-  exec 'hi! def link NERDTreeFlags NERDTreeFile'
-else
-  exec 'hi def link '.identifier.' NERDTreeFlags'
-endif
-if exists('g:WebDevIconsDefaultFileSymbolColor')
-  call s:X(identifier, g:WebDevIconsDefaultFileSymbolColor, '', '')
+if exists("g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol")
+  let icon = g:WebDevIconsUnicodeDecorateFileNodesDefaultSymbol
+  let identifier = 'WebDevIconsDefaultFileSymbol '
+  exec 'silent syn match '.identifier.' "\v\c\zs['.icon.']\ze.*" containedin=NERDTreeFlags'
+  if !exists('g:WebDevIconsDisableDefaultFileSymbolColorFromNERDTreeFile')
+    exec 'hi def link '.identifier.' NERDTreeFile'
+    exec 'hi! def link NERDTreeFlags NERDTreeFile'
+  else
+    exec 'hi def link '.identifier.' NERDTreeFlags'
+  endif
+  if exists('g:WebDevIconsDefaultFileSymbolColor')
+    call s:X(identifier, g:WebDevIconsDefaultFileSymbolColor, '', '')
+  endif
 endif


### PR DESCRIPTION
Hi -- thanks for the great plugin!

6225131f1fab7782a05b8cf3fc3d6483f84638b5 seems to have broken support for Vim installations without `vim-devicons` (I was seeing the same as #37); I just suppressed the issue by shoving the problematic bits into an if statement.

resolves #37