### PR TITLE
Escape keys with invalid characters

### DIFF
--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -270,7 +270,6 @@ let s:file_extension_colors = {
   \ 'ico'      : s:aqua,
   \ 'twig'     : s:green,
   \ 'cpp'      : s:blue,
-  \ 'c++'      : s:blue,
   \ 'cxx'      : s:blue,
   \ 'cc'       : s:blue,
   \ 'cp'       : s:blue,
@@ -312,7 +311,6 @@ let s:file_extension_colors = {
   \ 'pm'       : s:blue,
   \ 't'        : s:blue,
   \ 'rss'      : s:darkOrange,
-  \ 'f#'       : s:darkBlue,
   \ 'fsscript' : s:blue,
   \ 'fsx'      : s:blue,
   \ 'fs'       : s:blue,
@@ -352,7 +350,6 @@ let s:file_node_exact_matches = {
   \ '.ds_store'                        : s:white,
   \ '.gitconfig'                       : s:white,
   \ '.gitignore'                       : s:white,
-  \ '.gitlab-ci.yml'                   : s:orange,
   \ '.bashrc'                          : s:white,
   \ '.zshrc'                           : s:white,
   \ '.vimrc'                           : s:green,
@@ -368,7 +365,6 @@ let s:file_node_exact_matches = {
   \ 'typescript.tsx'                   : s:blue,
   \ 'procfile'                         : s:purple,
   \ 'dockerfile'                       : s:blue,
-  \ 'docker-compose.yml'               : s:blue,
   \ 'makefile'                         : s:white,
   \ 'cmakelists.txt'                   : s:white
 \}

--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -209,11 +209,7 @@ endfun
 
 " Escape a string so that it may be used as a group name.
 fun! s:escape(str)
-  let l:escaped = a:str
-  let l:escaped = substitute(l:escaped, "+", ".PLUS.", "g")
-  let l:escaped = substitute(l:escaped, "-", ".MINUS.", "g")
-  let l:escaped = substitute(l:escaped, "#", ".HASH.", "g")
-  return l:escaped
+  return substitute(a:str, '[a-zA-Z0-9_.@]\@!.', '_', 'g')
 endfun
 
 "the original values would be 24 bit color but apparently that is not possible

--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -207,6 +207,15 @@ fun! s:X(group, fg, bg, attr)
   endif
 endfun
 
+" Escape a string so that it may be used as a group name.
+fun! s:escape(str)
+  let l:escaped = a:str
+  let l:escaped = substitute(l:escaped, "+", ".PLUS.", "g")
+  let l:escaped = substitute(l:escaped, "-", ".MINUS.", "g")
+  let l:escaped = substitute(l:escaped, "#", ".HASH.", "g")
+  return l:escaped
+endfun
+
 "the original values would be 24 bit color but apparently that is not possible
 let s:brown = "905532"
 let s:aqua =  "3AFFDB"
@@ -451,8 +460,9 @@ for [key, val] in items(s:file_extension_colors)
 endfor
 
 for [key, val] in items(g:NERDTreeExtensionHighlightColor)
-  let label_identifier = 'nerdtreeFileExtensionLabel_'.key
-  let icon_identifier = 'nerdtreeFileExtensionIcon_'.key
+  let escaped = s:escape(key)
+  let label_identifier = 'nerdtreeFileExtensionLabel_'.escaped
+  let icon_identifier = 'nerdtreeFileExtensionIcon_'.escaped
   let regexp = '\v'.s:characters.'+\.'.substitute(key, '\W', '\\\0', 'g')
 
   exec 'silent syn match '.label_identifier.' "'.regexp.'$" containedin=NERDTreeFile'
@@ -488,10 +498,11 @@ for [key, val] in items(s:file_node_exact_matches)
 endfor
 
 for [key, val] in items(g:NERDTreeExactMatchHighlightColor)
-  let label_identifier = 'nerdtreeExactMatchLabel_'.key
-  let icon_identifier = 'nerdtreeExactMatchIcon_'.key
-  let folder_identifier = 'nerdtreeExactMatchFolder_'.key
-  let folder_icon_identifier = 'nerdtreeExactMatchFolderIcon_'.key
+  let escaped = s:escape(key)
+  let label_identifier = 'nerdtreeExactMatchLabel_'.escaped
+  let icon_identifier = 'nerdtreeExactMatchIcon_'.escaped
+  let folder_identifier = 'nerdtreeExactMatchFolder_'.escaped
+  let folder_icon_identifier = 'nerdtreeExactMatchFolderIcon_'.escaped
   exec 'silent syn match '.label_identifier.' "\c'.key.'$" containedin=NERDTreeFile'
   exec 'silent syn match '.label_identifier.' "\c'.key.'\W*\*$" containedin=NERDTreeExecFile'
   exec 'hi def link '.label_identifier.' NERDTreeFile'
@@ -533,7 +544,8 @@ for [key, val] in items(s:file_node_pattern_matches)
 endfor
 
 for [key, val] in items(g:NERDTreePatternMatchHighlightColor)
-  let suffix = substitute(key, '\W', '', 'g')
+  let escaped = s:escape(key)
+  let suffix = substitute(escaped, '\W', '', 'g')
   let label_identifier = 'nerdtreePatternMatchLabel_'.suffix
   let icon_identifier = 'nerdtreePatternMatchIcon_'.suffix
   let sub_regexp = substitute(key, '\v\\@<!\.', s:chars_double_lashes, 'g')

--- a/after/syntax/nerdtree.vim
+++ b/after/syntax/nerdtree.vim
@@ -270,6 +270,7 @@ let s:file_extension_colors = {
   \ 'ico'      : s:aqua,
   \ 'twig'     : s:green,
   \ 'cpp'      : s:blue,
+  \ 'c++'      : s:blue,
   \ 'cxx'      : s:blue,
   \ 'cc'       : s:blue,
   \ 'cp'       : s:blue,
@@ -311,6 +312,7 @@ let s:file_extension_colors = {
   \ 'pm'       : s:blue,
   \ 't'        : s:blue,
   \ 'rss'      : s:darkOrange,
+  \ 'f#'       : s:darkBlue,
   \ 'fsscript' : s:blue,
   \ 'fsx'      : s:blue,
   \ 'fs'       : s:blue,
@@ -350,6 +352,7 @@ let s:file_node_exact_matches = {
   \ '.ds_store'                        : s:white,
   \ '.gitconfig'                       : s:white,
   \ '.gitignore'                       : s:white,
+  \ '.gitlab-ci.yml'                   : s:orange,
   \ '.bashrc'                          : s:white,
   \ '.zshrc'                           : s:white,
   \ '.vimrc'                           : s:green,
@@ -365,6 +368,7 @@ let s:file_node_exact_matches = {
   \ 'typescript.tsx'                   : s:blue,
   \ 'procfile'                         : s:purple,
   \ 'dockerfile'                       : s:blue,
+  \ 'docker-compose.yml'               : s:blue,
   \ 'makefile'                         : s:white,
   \ 'cmakelists.txt'                   : s:white
 \}


### PR DESCRIPTION
As of nvim v0.8.0 because of [this commit](https://github.com/neovim/neovim/commit/61be343ec8c5e4d504db7ba975b20af2f46ce50d#diff-0cb0499adc01b42937b9626782911534f0df700663756f193a8a6cdb1c70d368) Groups with invalid characters will result to an error.